### PR TITLE
feature:F1 Help and Aliases for ChatCommands

### DIFF
--- a/ZeepSDK/ChatCommands/ChatCommandApi.cs
+++ b/ZeepSDK/ChatCommands/ChatCommandApi.cs
@@ -32,11 +32,15 @@ public static class ChatCommandApi
     /// <param name="command">The keyword for the command</param>
     /// <param name="description">The description for the command</param>
     /// <param name="callback">The callback to invoke whenever the command gets used</param>
+    /// <param name="aliases">The aliases that can be used in place of the keyword</param>
+    /// <param name="arguments">The arguments that this command takes</param>
     public static void RegisterLocalChatCommand(
         string prefix,
         string command,
         string description,
-        LocalChatCommandCallbackDelegate callback
+        LocalChatCommandCallbackDelegate callback,
+        string[] aliases = null,
+        string[] arguments = null
     )
     {
         try
@@ -44,7 +48,9 @@ public static class ChatCommandApi
             ChatCommandRegistry.RegisterLocalChatCommand(new LocalChatCommandWrapper(prefix,
                 command,
                 description,
-                callback));
+                callback,
+                aliases,
+                arguments));
         }
         catch (Exception e)
         {
@@ -62,6 +68,22 @@ public static class ChatCommandApi
         try
         {
             ChatCommandRegistry.RegisterLocalChatCommand(new TChatCommand());
+        }
+        catch (Exception e)
+        {
+            logger.LogError($"Unhandled exception in {nameof(RegisterLocalChatCommand)}: " + e);
+        }
+    }
+
+    /// <summary>
+    /// Allows you to register a local chat command
+    /// </summary>
+    /// <param name="commandGroup">command group to register</param>
+    public static void RegisterLocalChatCommandGroup(LocalChatCommandGroup commandGroup)
+    {
+        try
+        {
+            ChatCommandRegistry.RegisterLocalChatCommandGroup(commandGroup);
         }
         catch (Exception e)
         {

--- a/ZeepSDK/ChatCommands/ChatCommandRegistry.cs
+++ b/ZeepSDK/ChatCommands/ChatCommandRegistry.cs
@@ -13,6 +13,13 @@ internal static class ChatCommandRegistry
     public static void RegisterLocalChatCommand(ILocalChatCommand chatCommand)
     {
         localChatCommands.Add(chatCommand);
+        LocalChatCommandF1Help.addCommands(ChatCommandUtilities.GetHelpString(chatCommand));
+    }
+
+    public static void RegisterLocalChatCommandGroup(LocalChatCommandGroup chatCommandGroup)
+    {
+		localChatCommands.Add(chatCommandGroup);
+        LocalChatCommandF1Help.addCommands(chatCommandGroup.helpString());
     }
 
     public static void RegisterRemoteChatCommand(IRemoteChatCommand chatCommand)

--- a/ZeepSDK/ChatCommands/ChatCommandUtilities.cs
+++ b/ZeepSDK/ChatCommands/ChatCommandUtilities.cs
@@ -9,12 +9,62 @@ internal static class ChatCommandUtilities
         string escapedPrefix = Regex.Escape(chatCommand.Prefix);
         string escapedCommand = Regex.Escape(chatCommand.Command);
         string pattern = $"^{escapedPrefix}{escapedCommand}(\\W|$).*";
-        return Regex.IsMatch(input, pattern);
+        if (Regex.IsMatch(input, pattern)) {
+            return true;
+        }
+        else
+        {
+            for (int aliasIndex = 0; aliasIndex < chatCommand.Aliases.Length; ++aliasIndex)
+            {
+                escapedCommand = Regex.Escape(chatCommand.Aliases[aliasIndex]);
+                pattern = $"^{escapedPrefix}{escapedCommand}(\\W|$).*";
+                if (Regex.IsMatch(input, pattern)) return true;
+            }
+            return false;
+        }
     }
 
     public static string GetArguments(string input, IChatCommand chatCommand)
     {
         string args = input[chatCommand.Prefix.Length..];
+        for (int aliasIndex = 0; aliasIndex < chatCommand.Aliases.Length; ++aliasIndex)
+        {
+            if (args.Length >= chatCommand.Aliases[aliasIndex].Length && args[..chatCommand.Aliases[aliasIndex].Length] == chatCommand.Aliases[aliasIndex]) {
+                return args[chatCommand.Aliases[aliasIndex].Length..].Trim();
+            }
+        }
         return args[chatCommand.Command.Length..].Trim();
     }
+
+
+	public static string GetHelpString(IChatCommand chatCommand)
+	{
+		string commandsString = $"{chatCommand.Prefix}{chatCommand.Command}";
+
+		foreach (string arg in chatCommand.Arguments)
+		{
+			commandsString += $" [{arg}]";
+		}
+		commandsString += $" <color=#FF8800>-- {chatCommand.Description}</color>";
+
+		for (int aliasIdx = 0; aliasIdx < chatCommand.Aliases.Length; ++aliasIdx)
+		{
+			if (aliasIdx == 0)
+			{
+				commandsString += " <color=#407AFF>(aliases;";
+			}
+
+			commandsString += $" {chatCommand.Aliases[aliasIdx]}";
+
+			if (aliasIdx == chatCommand.Aliases.Length - 1)
+			{
+				commandsString += ")</color>";
+			}
+			else
+			{
+				commandsString += ",";
+			}
+		}
+		return commandsString;
+	}
 }

--- a/ZeepSDK/ChatCommands/Commands/ClearChatLocalChatCommand.cs
+++ b/ZeepSDK/ChatCommands/Commands/ClearChatLocalChatCommand.cs
@@ -7,6 +7,8 @@ internal class ClearChatLocalChatCommand : ILocalChatCommand
     public string Prefix => "/";
     public string Command => "clear";
     public string Description => "Clears the chat";
+    public string[] Aliases => [];
+    public string[] Arguments => [];
 
     public void Handle(string arguments)
     {

--- a/ZeepSDK/ChatCommands/Commands/HelpLocalChatCommand.cs
+++ b/ZeepSDK/ChatCommands/Commands/HelpLocalChatCommand.cs
@@ -10,37 +10,11 @@ internal class HelpLocalChatCommand : ILocalChatCommand
     public string Prefix => "/";
     public string Command => "help";
     public string Description => "Shows all locally available commands";
+    public string[] Aliases => [];
+    public string[] Arguments => [];
 
     public void Handle(string arguments)
     {
-        List<IEnumerable<ILocalChatCommand>> chunks = ChatCommandRegistry.LocalChatCommands.Chunk(5).ToList();
-
-        ChatApi.AddLocalMessage("Available commands:");
-
-        int page = 0;
-
-        if (int.TryParse(arguments, out int parsedPage))
-        {
-            page = parsedPage - 1;
-        }
-
-        if (page >= chunks.Count)
-        {
-            page = chunks.Count - 1;
-        }
-        else if (page < 1)
-        {
-            page = 0;
-        }
-
-        IEnumerable<ILocalChatCommand> chunk = chunks[page];
-
-        foreach (ILocalChatCommand localChatCommand in chunk)
-        {
-            ChatApi.AddLocalMessage(
-                $"- {localChatCommand.Prefix}{localChatCommand.Command} - {localChatCommand.Description}");
-        }
-
-        ChatApi.AddLocalMessage($"Page {page + 1}/{chunks.Count}");
+        ChatApi.AddLocalMessage("For available commands use F1, then spacebar to toggle through command pages");
     }
 }

--- a/ZeepSDK/ChatCommands/Commands/HelpRemoteChatCommand.cs
+++ b/ZeepSDK/ChatCommands/Commands/HelpRemoteChatCommand.cs
@@ -7,6 +7,8 @@ internal class HelpRemoteChatCommand : IRemoteChatCommand
     public string Prefix => "!";
     public string Command => "help";
     public string Description => "Shows all remotely available commands";
+    public string[] Aliases => [];
+    public string[] Arguments => [];
 
     public void Handle(ulong playerId, string arguments)
     {

--- a/ZeepSDK/ChatCommands/IChatCommand.cs
+++ b/ZeepSDK/ChatCommands/IChatCommand.cs
@@ -19,7 +19,17 @@ public interface IChatCommand
     string Command { get; }
 
     /// <summary>
+    /// The aliases of this chat command
+    /// </summary>
+    string[] Aliases { get; }
+
+    /// <summary>
+    /// The names of the arguments this chat command takes
+    /// </summary>
+    public string[] Arguments { get; }
+
+    /// <summary>
     /// The description of this chat command
     /// </summary>
-    string Description { get; }
+    public string Description { get; }
 }

--- a/ZeepSDK/ChatCommands/LocalChatCommandF1Help.cs
+++ b/ZeepSDK/ChatCommands/LocalChatCommandF1Help.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+internal static class LocalChatCommandF1Help
+{
+    private static List<LocalChatCommandHelpPage> commandPages = new List<LocalChatCommandHelpPage>();
+	private static int currentPage;
+
+    public static void registerBaseGameCommands(OnlineGameplayUI instance)
+    {
+		LocalChatCommandHelpPage firstPage = new LocalChatCommandHelpPage();
+
+        GameObject commands = instance.tooltips.transform.GetChild(0).gameObject;
+        TextMeshProUGUI commandsText = commands.GetComponent<TextMeshProUGUI>();
+        firstPage.addLines(commandsText.text);
+
+		commandPages.Insert(0, firstPage);
+		currentPage = 0;
+        commandsText.text = getPage();
+    }
+
+	public static void nextPage(OnlineGameplayUI instance)
+	{
+		if (instance.showTooltip && instance.OnlineTabLeaderboard.SwitchAction.buttonDown)
+		{
+			GameObject commands = instance.tooltips.transform.GetChild(0).gameObject;
+			TextMeshProUGUI commandsText = commands.GetComponent<TextMeshProUGUI>();
+			pageChange();
+			commandsText.text = getPage();
+		}
+	}
+
+	public static int getCurrentPage() { return currentPage; }
+
+	public static int getPageCount() { return commandPages.Count; }
+
+	private static string getPage()
+	{
+		if (commandPages.Count == 0) return "";
+		else
+		{
+			return commandPages[currentPage].getText();
+		}
+	}
+
+	private static void pageChange()
+	{
+		if (commandPages.Count == 0) return;
+
+		currentPage = ((currentPage + 1) % commandPages.Count);
+	}
+
+	public static void addCommands(string commands)
+	{
+		// Try to all lines on an existing page
+		foreach (LocalChatCommandHelpPage page in commandPages)
+		{
+			if (page.addLines(commands)) return;
+		}
+
+		addPage(commands);
+	}
+
+	private static void addPage(string commands)
+	{
+		LocalChatCommandHelpPage newPage = new LocalChatCommandHelpPage();
+
+		// Try to add all lines on the same new page
+		if (newPage.addLines(commands))
+		{
+			commandPages.Add(newPage);
+			return;
+		}
+
+		// Add lines individually since that didn't work
+		foreach (string line in commands.Split('\n'))
+		{
+            if (!newPage.addSingleLine(line))
+			{
+				commandPages.Add(newPage);
+				newPage = new LocalChatCommandHelpPage();
+			}
+		}
+
+		commandPages.Add(newPage);
+	}
+}

--- a/ZeepSDK/ChatCommands/LocalChatCommandGroup.cs
+++ b/ZeepSDK/ChatCommands/LocalChatCommandGroup.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using ZeepSDK.ChatCommands;
+
+public class LocalChatCommandGroup : ILocalChatCommand
+{
+    private LocalChatCommandCallbackDelegate callback;
+
+    public string Prefix { get; }
+    public string Command { get; }
+    public string Description { get; }
+    public string[] Aliases { get; }
+    public string[] Arguments { get; }
+
+	public LocalChatCommandGroup(string prefix, string command, string description, LocalChatCommandCallbackDelegate defaultCallback = null, string[] aliases = null, string[] arguments = null)
+	{
+		Prefix = prefix;
+		Command = command;
+		Description = description;
+		callback = defaultCallback;
+		Aliases = aliases ?? [];
+		Arguments = arguments ?? [];
+		subCommands = new List<LocalChatCommandWrapper>();
+	}
+
+	public void registerSubcommand(string function, string description, LocalChatCommandCallbackDelegate handle = null, string[] subAliases = null, params string[] arguments)
+	{
+		LocalChatCommandWrapper subcommand = new LocalChatCommandWrapper("", function, description, handle, subAliases, arguments);
+		subCommands.Add(subcommand);
+	}
+
+	public string helpString()
+	{
+		string commandsString = "";
+		if (subCommands.Count > 0 || Aliases.Length > 0)
+		{
+			commandsString += $"<color=#FFDD00>{Prefix}{Command}";
+			foreach (string alias in Aliases)
+			{
+				commandsString += $" | {Prefix}{alias}";
+			}
+			commandsString += "</color>";
+
+			if (subCommands.Count == 0 && Arguments.Length == 0)
+			{
+				commandsString += $" <color=#FF8800>-- {Description}</color>";
+			}
+
+			foreach (LocalChatCommandWrapper subcommand in subCommands)
+			{
+				commandsString += $"\n{Prefix}{Command} {ChatCommandUtilities.GetHelpString(subcommand)}";
+			}
+
+			if (Arguments.Length > 0)
+			{
+				commandsString += $"\n{Prefix}{Command}";
+				foreach (string arg in Arguments)
+				{
+					commandsString += $" [{arg}]";
+				}
+				commandsString += $" <color=#FF8800>-- {Description}</color>";
+			}
+		}
+		else
+		{
+			commandsString += ChatCommandUtilities.GetHelpString(this);
+		}
+		return commandsString;
+	}
+
+	public void Handle(string arguments)
+	{
+		foreach (LocalChatCommandWrapper subcommand in subCommands)
+		{
+			if (ChatCommandUtilities.MatchesCommand(arguments, subcommand))
+			{
+				subcommand.Handle(ChatCommandUtilities.GetArguments(arguments, subcommand));
+				return;
+			}
+		}
+		callback?.Invoke(arguments);
+	}
+
+	private List<LocalChatCommandWrapper> subCommands;
+}

--- a/ZeepSDK/ChatCommands/LocalChatCommandHelpPage.cs
+++ b/ZeepSDK/ChatCommands/LocalChatCommandHelpPage.cs
@@ -1,0 +1,63 @@
+﻿internal class LocalChatCommandHelpPage
+{
+	private const int MAX_LINES_PER_PAGE = 38;
+
+	private int linesUsed = 0;
+	private bool groupedLast = false;
+	private string textString = "";
+
+	public LocalChatCommandHelpPage() {}
+
+	public string getText() => textString;
+
+	public bool addSingleLine(string lineToAdd)
+	{
+		int linesRequired = groupedLast ? 2 : 0;
+
+		if (linesRequired + linesUsed > MAX_LINES_PER_PAGE) return false;
+
+		if (groupedLast)
+		{
+			addLine("");
+			addLine("");
+		}
+		addLine(lineToAdd);
+		groupedLast = false;
+
+		return true;
+	}
+
+	public bool addLines(string linesToAdd)
+	{
+		string[] commandLines = linesToAdd.Split('\n');
+		if (commandLines.Length == 1) return addSingleLine(commandLines[0]);
+
+		int linesRequired = groupedLast ? 2 : 0;
+		foreach (string commandLine in commandLines)
+		{
+			++linesRequired;
+		}
+
+		if (linesRequired + linesUsed > MAX_LINES_PER_PAGE) return false;
+
+		if (linesUsed > 0)
+		{
+			addLine("");
+			addLine("");
+		}
+		foreach (string commandLine in commandLines)
+		{
+			addLine(commandLine);
+		}
+
+		groupedLast = true;
+		return true;
+	}
+
+	private void addLine(string line)
+	{
+		if (linesUsed > 0) textString += '\n';
+		textString += line;
+		++linesUsed;
+	}
+}

--- a/ZeepSDK/ChatCommands/LocalChatCommandWrapper.cs
+++ b/ZeepSDK/ChatCommands/LocalChatCommandWrapper.cs
@@ -7,18 +7,24 @@ internal class LocalChatCommandWrapper : ILocalChatCommand
     public string Prefix { get; }
     public string Command { get; }
     public string Description { get; }
+    public string[] Aliases { get; }
+    public string[] Arguments { get; }
 
     public LocalChatCommandWrapper(
         string prefix,
         string command,
         string description,
-        LocalChatCommandCallbackDelegate callback
+        LocalChatCommandCallbackDelegate callback,
+        string[] aliases = null,
+        string[] arguments = null
     )
     {
         Prefix = prefix;
         Command = command;
         Description = description;
         this.callback = callback;
+        Aliases = aliases ?? [];
+        Arguments = arguments ?? [];
     }
 
     public void Handle(string arguments)

--- a/ZeepSDK/ChatCommands/MixedChatCommandBase.cs
+++ b/ZeepSDK/ChatCommands/MixedChatCommandBase.cs
@@ -14,6 +14,12 @@ public abstract class MixedChatCommandBase : IMixedChatCommand
     /// <inheritdoc />
     public abstract string Description { get; }
 
+    /// <inheritdoc />
+    public abstract string[] Aliases { get; }
+
+    /// <inheritdoc />
+    public abstract string[] Arguments { get; }
+
     void IRemoteChatCommand.Handle(ulong playerId, string arguments)
     {
         Handle(false, playerId, arguments);

--- a/ZeepSDK/ChatCommands/MixedChatCommandWrapper.cs
+++ b/ZeepSDK/ChatCommands/MixedChatCommandWrapper.cs
@@ -9,6 +9,8 @@ internal class MixedChatCommandWrapper : MixedChatCommandBase
     public override string Prefix { get; }
     public override string Command { get; }
     public override string Description { get; }
+    public override string[] Aliases { get; }
+    public override string[] Arguments { get; }
 
     public MixedChatCommandWrapper(
         string prefix,
@@ -21,6 +23,8 @@ internal class MixedChatCommandWrapper : MixedChatCommandBase
         Command = command;
         Description = description;
         this.callback = callback;
+        Aliases = [];
+        Arguments = [];
     }
 
     protected override void Handle(bool isLocal, ulong playerId, string arguments)

--- a/ZeepSDK/ChatCommands/RemoteChatCommandWrapper.cs
+++ b/ZeepSDK/ChatCommands/RemoteChatCommandWrapper.cs
@@ -7,6 +7,8 @@ internal class RemoteChatCommandWrapper : IRemoteChatCommand
     public string Prefix { get; }
     public string Command { get; }
     public string Description { get; }
+    public string[] Aliases { get; }
+    public string[] Arguments { get; }
 
     public RemoteChatCommandWrapper(
         string prefix,
@@ -19,6 +21,8 @@ internal class RemoteChatCommandWrapper : IRemoteChatCommand
         Command = command;
         Description = description;
         this.callback = callback;
+        Aliases = [];
+        Arguments = [];
     }
 
     public void Handle(ulong playerId, string arguments)

--- a/ZeepSDK/UI/Patches/OnlineGameplayUI_Update.cs
+++ b/ZeepSDK/UI/Patches/OnlineGameplayUI_Update.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using HarmonyLib;
+using TMPro;
+using UnityEngine;
+
+[HarmonyPatch(typeof(OnlineGameplayUI), "Update")]
+public class OnlineGameplayUI_Update
+{
+    public static event Action<OnlineGameplayUI> Update;
+
+    private static void Postfix(OnlineGameplayUI __instance)
+    {
+        Update?.Invoke(__instance);
+    }
+}

--- a/ZeepSDK/UI/UIApi.cs
+++ b/ZeepSDK/UI/UIApi.cs
@@ -3,8 +3,10 @@ using BepInEx.Logging;
 using UnityEngine;
 using UnityEngine.UI;
 using ZeepSDK.Extensions;
+using ZeepSDK.Racing.Patches;
 using ZeepSDK.UI.Patches;
 using ZeepSDK.Utilities;
+using ZeepSDK.ChatCommands;
 
 namespace ZeepSDK.UI;
 
@@ -24,6 +26,7 @@ public static class UIApi
 
         OnlineChatUI_Awake.Awake += OnOnlineChatUIAwake;
         OnlineGameplayUI_Awake.Awake += OnOnlineGameplayUIAwake;
+        OnlineGameplayUI_Update.Update += OnOnlineGameplayUIUpdate;
         PlayerScreensUI_Awake.Awake += OnPlayerScreensUIAwake;
         SpectatorCameraUI_Awake.Awake += OnSpectatorCameraUIAwake;
     }
@@ -40,6 +43,12 @@ public static class UIApi
             return;
 
         AddToConfigurator(gameplayUi.GetComponentsInDirectDescendants<RectTransform>());
+        LocalChatCommandF1Help.registerBaseGameCommands(instance);
+    }
+
+    private static void OnOnlineGameplayUIUpdate(OnlineGameplayUI instance)
+    {
+        LocalChatCommandF1Help.nextPage(instance);
     }
 
     private static void OnPlayerScreensUIAwake(PlayerScreensUI instance)

--- a/ZeepSDK/ZeepSDK.csproj
+++ b/ZeepSDK/ZeepSDK.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>ZeepSDK</AssemblyName>
         <Description>ZeepSDK</Description>
         <Authors>TNRD</Authors>
-        <Version>1.35.10</Version>
+        <Version>1.35.11</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
         <Title>ZeepSDK</Title>


### PR DESCRIPTION
Added two new arguments to IChatCommand, Aliases and Arguments.
Aliases are so the command can be triggered by multiple different strings but still stay as a single registered command.
Arguments are purely for documentation, they don't affect the Handle of the command at all, but will appear in the help menu.

Also moved all of the "/help" display from the chatbox to the F1 commands menu. New pages will be added as new commands are registered. Pages can be cycled by using the spacebar when the menu is active.

Finally, added LocalChatCommandGroup, a class that can be used to keep relevant commands together (i.e. with the same prefix, but additional subcommands.
Example Command Group:
"/dummy"
"/dummy action1"
"/dummy actioin2"
These subcommands can be registered to the group so the Handle of the Group goes through each subcommand to execute its own handle.

URGENT NOTE: Because the Aliases and Arguments are optional parameters, but optional parameters are resolved on the calling side, mods using RegisterLocalChatCommand will need to be updated to work. Also any mods (such as GTR) that inherit from the chat command interfaces will need to be updated to implement the Aliases and Arguments getter function. There may be a more clever way to get around breaking mods in this way, but I didn't know how.

Let me know if you need me to make updates before merging this feature in, or feel free to just use it as a baseline and make it how you want.

Cheers, 
agix