### PR TITLE
fix: always parse adventure levels as JSON for V2 level hashing

### DIFF
--- a/ZeepSDK/Level/LevelApi.cs
+++ b/ZeepSDK/Level/LevelApi.cs
@@ -73,8 +73,11 @@ public static class LevelApi
                 return null;
 
             levelScriptableObject.ForceCheckIfOldOrNewData();
+            bool useV15LevelData = levelScriptableObject.useLevelV15Data ||
+                                   levelScriptableObject.UseAvonturenLevel ||
+                                   levelScriptableObject.IsAdventureLevel;
 
-            return levelScriptableObject.useLevelV15Data
+            return useV15LevelData
                 ? LevelHashV2Calculator.Calculate(levelScriptableObject.GetV15LevelData(), zeepHash)
                 : LevelHashV2Calculator.CalculateCsv(levelScriptableObject.GetOldLevelData(), zeepHash);
         }

--- a/ZeepSDK/ZeepSDK.csproj
+++ b/ZeepSDK/ZeepSDK.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>ZeepSDK</AssemblyName>
         <Description>ZeepSDK</Description>
         <Authors>TNRD</Authors>
-        <Version>2.3.0</Version>
+        <Version>2.3.1</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
         <Title>ZeepSDK</Title>


### PR DESCRIPTION
Server stores Adventure level data in JSON format. V2 hashing should always use JSON format for Adventure Levels (V18 adventure levels will be JSON-native) so that both ZeepSDK and the server generate the same XXH128 hash.

Using the raw CSV representation for older workshop items remains, so the server does not need to reconstruct CSV levels to JSON.