### PR TITLE
Feature/Tabbed settings

### DIFF
--- a/ZeepSDK/Settings/Drawers/ZeepSettingsDefaultDrawersBuilder.cs
+++ b/ZeepSDK/Settings/Drawers/ZeepSettingsDefaultDrawersBuilder.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using BepInEx.Configuration;
+using ZeepSDK.Settings;
 
 namespace ZeepSDK.Settings.Drawers;
 
@@ -8,44 +9,132 @@ namespace ZeepSDK.Settings.Drawers;
 /// </summary>
 internal static class ZeepSettingsDefaultDrawersBuilder
 {
+    private const float DefaultTabContentHeight = 560f;
+
     /// <summary>
     /// Builds the default drawer list: section header, entry, separator, and section spacing.
+    /// When tab configuration exists for the plugin, tabbed sections are rendered first and
+    /// unassigned sections are rendered flat below.
     /// </summary>
-    /// <param name="entriesBySection">Config entries grouped by section name.</param>
-    /// <param name="customLabels">Optional custom labels keyed by config definition.</param>
-    /// <param name="customDrawers">Optional custom draw callbacks keyed by config definition.</param>
     public static IEnumerable<IZeepSettingsDrawer> Build(
+        IReadOnlyDictionary<string, IReadOnlyList<ConfigEntryBase>> entriesBySection,
+        IReadOnlyDictionary<ConfigDefinition, string> customLabels = null,
+        IReadOnlyDictionary<ConfigDefinition, ModSettingsConfigEntryDrawDelegate> customDrawers = null,
+        string pluginGuid = null)
+    {
+        if (pluginGuid != null &&
+            ZeepSettingsTabsRegistry.TryGetTabs(pluginGuid, out var tabConfig) &&
+            tabConfig.Count > 0)
+        {
+            yield return CreateTabbedDrawer(tabConfig, entriesBySection, customLabels, customDrawers);
+
+            var assignedSections = ZeepSettingsTabsRegistry.GetAssignedSections(tabConfig);
+            foreach ((string section, IReadOnlyList<ConfigEntryBase> sectionEntries) in entriesBySection)
+            {
+                if (assignedSections.Contains(section))
+                    continue;
+
+                foreach (var drawer in BuildSectionDrawers(section, sectionEntries, customLabels, customDrawers))
+                    yield return drawer;
+            }
+
+            yield break;
+        }
+
+        foreach ((string section, IReadOnlyList<ConfigEntryBase> sectionEntries) in entriesBySection)
+        {
+            foreach (var drawer in BuildSectionDrawers(section, sectionEntries, customLabels, customDrawers))
+                yield return drawer;
+        }
+    }
+
+    public static IEnumerable<IZeepSettingsDrawer> BuildSectionDrawers(
+        string section,
+        IReadOnlyList<ConfigEntryBase> sectionEntries,
+        IReadOnlyDictionary<ConfigDefinition, string> customLabels = null,
+        IReadOnlyDictionary<ConfigDefinition, ModSettingsConfigEntryDrawDelegate> customDrawers = null)
+    {
+        yield return new ZeepSettingsHeaderDrawer(section);
+
+        var anyVisible = false;
+        foreach (var entry in sectionEntries)
+        {
+            if (ZeepSettingsEntryMetadata.IsHidden(entry))
+                continue;
+
+            anyVisible = true;
+
+            foreach (var drawer in BuildEntryDrawers(entry, customLabels, customDrawers))
+                yield return drawer;
+
+            yield return new ZeepSettingsSeparatorDrawer();
+        }
+
+        if (anyVisible)
+            yield return new ZeepSettingsSectionSpacingDrawer();
+    }
+
+    public static IEnumerable<IZeepSettingsDrawer> BuildEntryDrawers(
+        ConfigEntryBase entry,
+        IReadOnlyDictionary<ConfigDefinition, string> customLabels = null,
+        IReadOnlyDictionary<ConfigDefinition, ModSettingsConfigEntryDrawDelegate> customDrawers = null,
+        string explicitLabel = null)
+    {
+        if (ZeepSettingsEntryMetadata.IsHidden(entry))
+            yield break;
+
+        string label = explicitLabel;
+        if (label == null)
+            customLabels?.TryGetValue(entry.Definition, out label);
+
+        if (customDrawers != null && customDrawers.TryGetValue(entry.Definition, out var drawer))
+            yield return new ZeepSettingsCustomConfigEntryDrawer(entry, label, drawer);
+        else if (ZeepSettingsConfigEntryTypeDrawerRegistry.TryCreateDrawer(entry, label, out var typeDrawer))
+            yield return typeDrawer;
+        else
+            yield return new ZeepSettingsEntryDrawer(entry, label);
+    }
+
+    public static ZeepSettingsTabbedSectionsDrawer CreateTabbedDrawer(
+        IReadOnlyList<ModSettingsTabDefinition> tabConfig,
         IReadOnlyDictionary<string, IReadOnlyList<ConfigEntryBase>> entriesBySection,
         IReadOnlyDictionary<ConfigDefinition, string> customLabels = null,
         IReadOnlyDictionary<ConfigDefinition, ModSettingsConfigEntryDrawDelegate> customDrawers = null)
     {
-        foreach ((string section, IReadOnlyList<ConfigEntryBase> sectionEntries) in entriesBySection)
+        var tabs = new List<ZeepSettingsTabbedSectionsDrawer.TabContent>(tabConfig.Count);
+
+        foreach (var tab in tabConfig)
         {
-            yield return new ZeepSettingsHeaderDrawer(section);
-
-            var anyVisible = false;
-            foreach (var entry in sectionEntries)
+            var tabDrawers = new List<IZeepSettingsDrawer>();
+            foreach (var item in tab.Items)
             {
-                if (ZeepSettingsEntryMetadata.IsHidden(entry))
-                    continue;
+                switch (item)
+                {
+                    case ModSettingsTabSectionItem sectionItem:
+                        if (entriesBySection.TryGetValue(sectionItem.SectionName, out var sectionEntries))
+                        {
+                            tabDrawers.AddRange(
+                                BuildSectionDrawers(sectionItem.SectionName, sectionEntries, customLabels, customDrawers));
+                        }
 
-                anyVisible = true;
+                        break;
 
-                string label = null;
-                customLabels?.TryGetValue(entry.Definition, out label);
+                    case ModSettingsTabEntryItem entryItem:
+                        tabDrawers.AddRange(
+                            BuildEntryDrawers(entryItem.Entry, customLabels, customDrawers, entryItem.Label));
+                        tabDrawers.Add(new ZeepSettingsSeparatorDrawer());
+                        break;
 
-                if (customDrawers != null && customDrawers.TryGetValue(entry.Definition, out var drawer))
-                    yield return new ZeepSettingsCustomConfigEntryDrawer(entry, label, drawer);
-                else if (ZeepSettingsConfigEntryTypeDrawerRegistry.TryCreateDrawer(entry, label, out var typeDrawer))
-                    yield return typeDrawer;
-                else
-                    yield return new ZeepSettingsEntryDrawer(entry, label);
-
-                yield return new ZeepSettingsSeparatorDrawer();
+                    case ModSettingsTabDrawerItem drawerItem:
+                        tabDrawers.Add(drawerItem.Drawer);
+                        break;
+                }
             }
 
-            if (anyVisible)
-                yield return new ZeepSettingsSectionSpacingDrawer();
+            if (tabDrawers.Count > 0)
+                tabs.Add(new ZeepSettingsTabbedSectionsDrawer.TabContent(tab.Label, tabDrawers));
         }
+
+        return new ZeepSettingsTabbedSectionsDrawer(tabs, DefaultTabContentHeight);
     }
 }

--- a/ZeepSDK/Settings/Drawers/ZeepSettingsDefaultDrawersBuilder.cs
+++ b/ZeepSDK/Settings/Drawers/ZeepSettingsDefaultDrawersBuilder.cs
@@ -9,8 +9,6 @@ namespace ZeepSDK.Settings.Drawers;
 /// </summary>
 internal static class ZeepSettingsDefaultDrawersBuilder
 {
-    private const float DefaultTabContentHeight = 560f;
-
     /// <summary>
     /// Builds the default drawer list: section header, entry, separator, and section spacing.
     /// When tab configuration exists for the plugin, tabbed sections are rendered first and
@@ -135,6 +133,6 @@ internal static class ZeepSettingsDefaultDrawersBuilder
                 tabs.Add(new ZeepSettingsTabbedSectionsDrawer.TabContent(tab.Label, tabDrawers));
         }
 
-        return new ZeepSettingsTabbedSectionsDrawer(tabs, DefaultTabContentHeight);
+        return new ZeepSettingsTabbedSectionsDrawer(tabs);
     }
 }

--- a/ZeepSDK/Settings/Drawers/ZeepSettingsDrawContext.cs
+++ b/ZeepSDK/Settings/Drawers/ZeepSettingsDrawContext.cs
@@ -9,11 +9,6 @@ namespace ZeepSDK.Settings.Drawers;
 /// </summary>
 public sealed class ZeepSettingsDrawContext
 {
-    /// <summary>
-    /// Available height for tabbed settings content. Set by the settings window before drawing tabbed layouts.
-    /// </summary>
-    public float AvailableContentHeight { get; internal set; }
-
     internal Action<ConfigEntry<KeyCode>> OpenKeyCodePopupInternal { get; init; }
 
     /// <summary>

--- a/ZeepSDK/Settings/Drawers/ZeepSettingsDrawContext.cs
+++ b/ZeepSDK/Settings/Drawers/ZeepSettingsDrawContext.cs
@@ -9,6 +9,11 @@ namespace ZeepSDK.Settings.Drawers;
 /// </summary>
 public sealed class ZeepSettingsDrawContext
 {
+    /// <summary>
+    /// Available height for tabbed settings content. Set by the settings window before drawing tabbed layouts.
+    /// </summary>
+    public float AvailableContentHeight { get; internal set; }
+
     internal Action<ConfigEntry<KeyCode>> OpenKeyCodePopupInternal { get; init; }
 
     /// <summary>

--- a/ZeepSDK/Settings/Drawers/ZeepSettingsTabbedSectionsDrawer.cs
+++ b/ZeepSDK/Settings/Drawers/ZeepSettingsTabbedSectionsDrawer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Imui.Controls;
 using Imui.Core;
+using UnityEngine;
 
 namespace ZeepSDK.Settings.Drawers;
 
@@ -22,14 +23,11 @@ public sealed class ZeepSettingsTabbedSectionsDrawer : IZeepSettingsDrawer
     }
 
     private readonly IReadOnlyList<TabContent> _tabs;
-    private readonly float _defaultHeight;
+    private int _selectedTabIndex;
 
-    internal ZeepSettingsTabbedSectionsDrawer(
-        IReadOnlyList<TabContent> tabs,
-        float defaultHeight = 560f)
+    internal ZeepSettingsTabbedSectionsDrawer(IReadOnlyList<TabContent> tabs)
     {
         _tabs = tabs;
-        _defaultHeight = defaultHeight;
     }
 
     /// <inheritdoc />
@@ -38,25 +36,40 @@ public sealed class ZeepSettingsTabbedSectionsDrawer : IZeepSettingsDrawer
         if (_tabs == null || _tabs.Count == 0)
             return;
 
-        var height = context.AvailableContentHeight > 0f
-            ? context.AvailableContentHeight
-            : _defaultHeight;
+        _selectedTabIndex = Mathf.Clamp(_selectedTabIndex, 0, _tabs.Count - 1);
 
         using (gui.Indent())
         {
-            gui.BeginTabsPane(gui.AddLayoutRect(gui.GetLayoutWidth(), height));
-            foreach (var tab in _tabs)
+            using (gui.Horizontal(gui.GetLayoutWidth()))
             {
-                if (gui.BeginTab(tab.Label))
+                for (var i = 0; i < _tabs.Count; i++)
                 {
-                    foreach (var drawer in tab.Drawers)
-                        drawer.Draw(gui, context);
-
-                    gui.EndTab();
+                    var tab = _tabs[i];
+                    gui.PushId((uint)i);
+                    {
+                        var controlId = gui.GetNextControlId();
+                        var rect = ImTabsPane.AddButtonRect(gui, tab.Label, default);
+                        if (ImTabsPane.TabBarButton(gui, controlId, _selectedTabIndex == i, tab.Label, rect))
+                            _selectedTabIndex = i;
+                    }
+                    gui.PopId();
                 }
             }
 
-            gui.EndTabsPane();
+            if (gui.Style.Tabs.SeparatorThickness > 0f)
+            {
+                var sepRect = gui.AddLayoutRect(gui.GetLayoutWidth(), gui.Style.Tabs.SeparatorThickness);
+                gui.Canvas.Rect(sepRect, gui.Style.Tabs.SeparatorColor);
+            }
+
+            gui.AddSpacing(gui.Style.Layout.Spacing);
+
+            gui.PushId((uint)_selectedTabIndex);
+            {
+                foreach (var drawer in _tabs[_selectedTabIndex].Drawers)
+                    drawer.Draw(gui, context);
+            }
+            gui.PopId();
         }
     }
 }

--- a/ZeepSDK/Settings/Drawers/ZeepSettingsTabbedSectionsDrawer.cs
+++ b/ZeepSDK/Settings/Drawers/ZeepSettingsTabbedSectionsDrawer.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using Imui.Controls;
+using Imui.Core;
+
+namespace ZeepSDK.Settings.Drawers;
+
+/// <summary>
+/// Draws grouped mod settings content in a tabbed layout.
+/// </summary>
+public sealed class ZeepSettingsTabbedSectionsDrawer : IZeepSettingsDrawer
+{
+    internal readonly struct TabContent
+    {
+        public string Label { get; }
+        public IReadOnlyList<IZeepSettingsDrawer> Drawers { get; }
+
+        public TabContent(string label, IReadOnlyList<IZeepSettingsDrawer> drawers)
+        {
+            Label = label;
+            Drawers = drawers;
+        }
+    }
+
+    private readonly IReadOnlyList<TabContent> _tabs;
+    private readonly float _defaultHeight;
+
+    internal ZeepSettingsTabbedSectionsDrawer(
+        IReadOnlyList<TabContent> tabs,
+        float defaultHeight = 560f)
+    {
+        _tabs = tabs;
+        _defaultHeight = defaultHeight;
+    }
+
+    /// <inheritdoc />
+    public void Draw(ImGui gui, ZeepSettingsDrawContext context)
+    {
+        if (_tabs == null || _tabs.Count == 0)
+            return;
+
+        var height = context.AvailableContentHeight > 0f
+            ? context.AvailableContentHeight
+            : _defaultHeight;
+
+        using (gui.Indent())
+        {
+            gui.BeginTabsPane(gui.AddLayoutRect(gui.GetLayoutWidth(), height));
+            foreach (var tab in _tabs)
+            {
+                if (gui.BeginTab(tab.Label))
+                {
+                    foreach (var drawer in tab.Drawers)
+                        drawer.Draw(gui, context);
+
+                    gui.EndTab();
+                }
+            }
+
+            gui.EndTabsPane();
+        }
+    }
+}

--- a/ZeepSDK/Settings/ModSettingsDrawerBuildContext.cs
+++ b/ZeepSDK/Settings/ModSettingsDrawerBuildContext.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using BepInEx;
 using BepInEx.Configuration;
 using ZeepSDK.Settings.Drawers;
@@ -28,6 +30,14 @@ public sealed class ModSettingsDrawerBuildContext
         EntriesBySection = entriesBySection;
     }
 
+    private string PluginGuid => Plugin.Metadata.GUID;
+
+    private IReadOnlyDictionary<ConfigDefinition, string> CustomLabels
+        => ZeepSettingsEntryLabelRegistry.GetLabels(PluginGuid);
+
+    private IReadOnlyDictionary<ConfigDefinition, ModSettingsConfigEntryDrawDelegate> CustomDrawers
+        => ZeepSettingsEntryDrawerRegistry.GetDrawers(PluginGuid);
+
     /// <summary>
     /// Creates the default drawer list for this plugin's config entries.
     /// </summary>
@@ -35,6 +45,86 @@ public sealed class ModSettingsDrawerBuildContext
     public IEnumerable<IZeepSettingsDrawer> CreateDefaultDrawers()
         => ZeepSettingsDefaultDrawersBuilder.Build(
             EntriesBySection,
-            ZeepSettingsEntryLabelRegistry.GetLabels(Plugin.Metadata.GUID),
-            ZeepSettingsEntryDrawerRegistry.GetDrawers(Plugin.Metadata.GUID));
+            CustomLabels,
+            CustomDrawers,
+            PluginGuid);
+
+    /// <summary>
+    /// Creates the default drawers for a single BepInEx config section.
+    /// </summary>
+    /// <param name="section">The BepInEx section name.</param>
+    /// <returns>Drawers for the section header, entries, separators, and trailing spacing.</returns>
+    public IEnumerable<IZeepSettingsDrawer> CreateSectionDrawers(string section)
+    {
+        if (!EntriesBySection.TryGetValue(section, out var entries))
+            return [];
+
+        return ZeepSettingsDefaultDrawersBuilder.BuildSectionDrawers(section, entries, CustomLabels, CustomDrawers);
+    }
+
+    /// <summary>
+    /// Creates flat section drawers for sections not assigned to a configured tab layout.
+    /// </summary>
+    /// <param name="excludeTabbedSections">
+    /// When <see langword="true"/>, sections assigned via <see cref="SettingsApi.ConfigureModSettingsTabs"/> are omitted.
+    /// </param>
+    /// <returns>Flat section drawers for the remaining sections.</returns>
+    public IEnumerable<IZeepSettingsDrawer> CreateFlatSectionDrawers(bool excludeTabbedSections)
+    {
+        HashSet<string> assignedSections = null;
+        if (excludeTabbedSections &&
+            ZeepSettingsTabsRegistry.TryGetTabs(PluginGuid, out var tabConfig) &&
+            tabConfig.Count > 0)
+        {
+            assignedSections = ZeepSettingsTabsRegistry.GetAssignedSections(tabConfig);
+        }
+
+        foreach ((string section, IReadOnlyList<ConfigEntryBase> sectionEntries) in EntriesBySection)
+        {
+            if (assignedSections != null && assignedSections.Contains(section))
+                continue;
+
+            foreach (var drawer in ZeepSettingsDefaultDrawersBuilder.BuildSectionDrawers(
+                         section, sectionEntries, CustomLabels, CustomDrawers))
+                yield return drawer;
+        }
+    }
+
+    /// <summary>
+    /// Creates a tabbed settings drawer from a tab configuration callback.
+    /// </summary>
+    /// <param name="configure">Builds the tab layout.</param>
+    /// <returns>A drawer that renders the configured tabs.</returns>
+    public ZeepSettingsTabbedSectionsDrawer CreateTabbedSectionsDrawer(Action<ModSettingsTabsBuilder> configure)
+    {
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
+
+        var builder = new ModSettingsTabsBuilder(EntriesBySection, PluginGuid);
+        configure(builder);
+        var tabConfig = builder.Build();
+
+        return ZeepSettingsDefaultDrawersBuilder.CreateTabbedDrawer(
+            tabConfig,
+            EntriesBySection,
+            CustomLabels,
+            CustomDrawers);
+    }
+
+    internal static Dictionary<string, IReadOnlyList<ConfigEntryBase>> BuildEntriesBySection(PluginInfo plugin)
+    {
+        var sections = new Dictionary<string, SortedList<string, ConfigEntryBase>>();
+
+        foreach ((ConfigDefinition definition, ConfigEntryBase entry) in plugin.Instance.Config)
+        {
+            if (!sections.TryGetValue(definition.Section, out var entries))
+                sections.Add(definition.Section, entries = []);
+
+            entries.Add(definition.Key, entry);
+        }
+
+        return sections.ToDictionary(
+            x => x.Key,
+            x => (IReadOnlyList<ConfigEntryBase>)[.. x.Value.Values]);
+    }
 }

--- a/ZeepSDK/Settings/ModSettingsTabDefinition.cs
+++ b/ZeepSDK/Settings/ModSettingsTabDefinition.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using BepInEx.Configuration;
+using JetBrains.Annotations;
+using ZeepSDK.Settings.Drawers;
+
+namespace ZeepSDK.Settings;
+
+/// <summary>
+/// A single item within a mod settings tab.
+/// </summary>
+[PublicAPI]
+public abstract class ModSettingsTabItem;
+
+/// <summary>
+/// Includes all visible config entries from a BepInEx section in a tab.
+/// </summary>
+[PublicAPI]
+public sealed class ModSettingsTabSectionItem : ModSettingsTabItem
+{
+    /// <summary>
+    /// The BepInEx config section name.
+    /// </summary>
+    public string SectionName { get; }
+
+    internal ModSettingsTabSectionItem(string sectionName) => SectionName = sectionName;
+}
+
+/// <summary>
+/// Includes a single config entry in a tab.
+/// </summary>
+[PublicAPI]
+public sealed class ModSettingsTabEntryItem : ModSettingsTabItem
+{
+    /// <summary>
+    /// The config entry to draw.
+    /// </summary>
+    public ConfigEntryBase Entry { get; }
+
+    /// <summary>
+    /// Optional display label. Uses the config key when omitted.
+    /// </summary>
+    public string Label { get; }
+
+    internal ModSettingsTabEntryItem(ConfigEntryBase entry, string label)
+    {
+        Entry = entry;
+        Label = label;
+    }
+}
+
+/// <summary>
+/// Includes a custom settings drawer in a tab.
+/// </summary>
+[PublicAPI]
+public sealed class ModSettingsTabDrawerItem : ModSettingsTabItem
+{
+    /// <summary>
+    /// The drawer to render.
+    /// </summary>
+    public IZeepSettingsDrawer Drawer { get; }
+
+    internal ModSettingsTabDrawerItem(IZeepSettingsDrawer drawer) => Drawer = drawer;
+}
+
+/// <summary>
+/// Defines a single tab in the mod settings panel.
+/// </summary>
+[PublicAPI]
+public sealed class ModSettingsTabDefinition
+{
+    /// <summary>
+    /// The label shown on the tab button.
+    /// </summary>
+    public string Label { get; }
+
+    /// <summary>
+    /// The ordered content of this tab.
+    /// </summary>
+    public IReadOnlyList<ModSettingsTabItem> Items { get; }
+
+    internal ModSettingsTabDefinition(string label, IReadOnlyList<ModSettingsTabItem> items)
+    {
+        Label = label;
+        Items = items;
+    }
+}

--- a/ZeepSDK/Settings/ModSettingsTabsBuilder.cs
+++ b/ZeepSDK/Settings/ModSettingsTabsBuilder.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using BepInEx.Configuration;
+using BepInEx.Logging;
+using JetBrains.Annotations;
+using ZeepSDK.Settings.Drawers;
+using ZeepSDK.Utilities;
+
+namespace ZeepSDK.Settings;
+
+/// <summary>
+/// Builds tab definitions for the mod settings panel.
+/// </summary>
+[PublicAPI]
+public sealed class ModSettingsTabsBuilder
+{
+    private static readonly ManualLogSource Logger = LoggerFactory.GetLogger(typeof(ModSettingsTabsBuilder));
+
+    private readonly List<ModSettingsTabDefinition> _tabs = [];
+    private readonly HashSet<string> _assignedSections = new(StringComparer.Ordinal);
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<ConfigEntryBase>> _entriesBySection;
+    private readonly string _pluginGuid;
+    private ModSettingsTabBuilder _currentTab;
+
+    internal ModSettingsTabsBuilder(
+        IReadOnlyDictionary<string, IReadOnlyList<ConfigEntryBase>> entriesBySection,
+        string pluginGuid = null)
+    {
+        _entriesBySection = entriesBySection ?? throw new ArgumentNullException(nameof(entriesBySection));
+        _pluginGuid = pluginGuid;
+    }
+
+    /// <summary>
+    /// Adds a tab with the given label and optional initial sections.
+    /// </summary>
+    /// <param name="label">The label shown on the tab button.</param>
+    /// <param name="sections">BepInEx section names to include in this tab.</param>
+    /// <returns>A builder for adding more content to this tab.</returns>
+    public ModSettingsTabBuilder Tab(string label, params string[] sections)
+    {
+        FinalizeCurrentTab();
+        _currentTab = new ModSettingsTabBuilder(label, this);
+        if (sections is { Length: > 0 })
+            _currentTab.Sections(sections);
+
+        return _currentTab;
+    }
+
+    internal void FinalizeCurrentTab()
+    {
+        if (_currentTab == null)
+            return;
+
+        if (_currentTab.ItemCount > 0)
+            _tabs.Add(_currentTab.ToDefinition());
+
+        _currentTab = null;
+    }
+
+    internal bool TryAddSection(string sectionName)
+    {
+        if (!_entriesBySection.ContainsKey(sectionName))
+        {
+            if (_pluginGuid != null)
+            {
+                Logger.LogWarning(
+                    $"Mod settings tab configuration for '{_pluginGuid}' references unknown section '{sectionName}'. Section was skipped.");
+            }
+
+            return false;
+        }
+
+        if (!_assignedSections.Add(sectionName))
+        {
+            if (_pluginGuid != null)
+            {
+                Logger.LogWarning(
+                    $"Mod settings tab configuration for '{_pluginGuid}' assigns section '{sectionName}' to multiple tabs. Section was skipped.");
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    internal IReadOnlyList<ModSettingsTabDefinition> Build()
+    {
+        FinalizeCurrentTab();
+        return _tabs;
+    }
+}
+
+/// <summary>
+/// Builds the content of a single mod settings tab.
+/// </summary>
+[PublicAPI]
+public sealed class ModSettingsTabBuilder
+{
+    private readonly string _label;
+    private readonly ModSettingsTabsBuilder _parent;
+    private readonly List<ModSettingsTabItem> _items = [];
+
+    internal ModSettingsTabBuilder(string label, ModSettingsTabsBuilder parent)
+    {
+        _label = label ?? throw new ArgumentNullException(nameof(label));
+        _parent = parent ?? throw new ArgumentNullException(nameof(parent));
+    }
+
+    internal int ItemCount => _items.Count;
+
+    /// <summary>
+    /// Adds all visible config entries from a BepInEx section to this tab.
+    /// </summary>
+    /// <param name="sectionName">The BepInEx config section name.</param>
+    /// <returns>This builder for chaining.</returns>
+    public ModSettingsTabBuilder Section(string sectionName)
+    {
+        if (string.IsNullOrEmpty(sectionName))
+            throw new ArgumentException("Section name cannot be null or empty.", nameof(sectionName));
+
+        if (!_parent.TryAddSection(sectionName))
+            return this;
+
+        _items.Add(new ModSettingsTabSectionItem(sectionName));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds all visible config entries from multiple BepInEx sections to this tab.
+    /// </summary>
+    /// <param name="sectionNames">The BepInEx config section names.</param>
+    /// <returns>This builder for chaining.</returns>
+    public ModSettingsTabBuilder Sections(params string[] sectionNames)
+    {
+        if (sectionNames == null)
+            throw new ArgumentNullException(nameof(sectionNames));
+
+        foreach (var sectionName in sectionNames)
+            Section(sectionName);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a single config entry to this tab.
+    /// </summary>
+    /// <param name="entry">The config entry to draw.</param>
+    /// <param name="label">Optional display label. Uses the config key when omitted.</param>
+    /// <returns>This builder for chaining.</returns>
+    public ModSettingsTabBuilder Entry(ConfigEntryBase entry, string label = null)
+    {
+        if (entry == null)
+            throw new ArgumentNullException(nameof(entry));
+
+        _items.Add(new ModSettingsTabEntryItem(entry, label));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom settings drawer to this tab.
+    /// </summary>
+    /// <param name="drawer">The drawer to render.</param>
+    /// <returns>This builder for chaining.</returns>
+    public ModSettingsTabBuilder Drawer(IZeepSettingsDrawer drawer)
+    {
+        if (drawer == null)
+            throw new ArgumentNullException(nameof(drawer));
+
+        _items.Add(new ModSettingsTabDrawerItem(drawer));
+        return this;
+    }
+
+    internal ModSettingsTabDefinition ToDefinition() => new(_label, _items);
+}

--- a/ZeepSDK/Settings/SettingsApi.cs
+++ b/ZeepSDK/Settings/SettingsApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using BepInEx;
+using BepInEx.Bootstrap;
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using JetBrains.Annotations;
@@ -72,6 +73,63 @@ public static class SettingsApi
     /// <param name="provider">The callback that builds the drawer list for this mod.</param>
     public static void RegisterModSettingsDrawers(string pluginGuid, ModSettingsDrawersDelegate provider)
         => ZeepSettingsDrawerRegistry.Register(pluginGuid, provider);
+
+    /// <summary>
+    /// Configures a tabbed layout for the given mod's default settings panel.
+    /// Sections assigned to tabs are merged into those tabs; unassigned sections render flat below the tab bar.
+    /// </summary>
+    /// <param name="plugin">The mod plugin instance to configure tabs for.</param>
+    /// <param name="configure">Builds the tab layout.</param>
+    public static void ConfigureModSettingsTabs(BaseUnityPlugin plugin, Action<ModSettingsTabsBuilder> configure)
+    {
+        if (plugin == null)
+            throw new ArgumentNullException(nameof(plugin));
+
+        ConfigureModSettingsTabs(plugin.Info.Metadata.GUID, configure, plugin.Info);
+    }
+
+    /// <summary>
+    /// Configures a tabbed layout for the given mod's default settings panel.
+    /// </summary>
+    /// <param name="pluginGuid">The BepInEx GUID of the mod to configure tabs for.</param>
+    /// <param name="configure">Builds the tab layout.</param>
+    public static void ConfigureModSettingsTabs(string pluginGuid, Action<ModSettingsTabsBuilder> configure)
+    {
+        if (!Chainloader.PluginInfos.TryGetValue(pluginGuid, out var pluginInfo))
+        {
+            Logger.LogWarning(
+                $"Cannot configure mod settings tabs for unknown plugin GUID '{pluginGuid}'.");
+            return;
+        }
+
+        ConfigureModSettingsTabs(pluginGuid, configure, pluginInfo);
+    }
+
+    private static void ConfigureModSettingsTabs(
+        string pluginGuid,
+        Action<ModSettingsTabsBuilder> configure,
+        PluginInfo pluginInfo)
+    {
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
+
+        var entriesBySection = ModSettingsDrawerBuildContext.BuildEntriesBySection(pluginInfo);
+        ZeepSettingsTabsRegistry.Configure(pluginGuid, configure, entriesBySection);
+    }
+
+    /// <summary>
+    /// Removes tab configuration for the given mod, restoring the default flat section layout.
+    /// </summary>
+    /// <param name="plugin">The mod plugin instance to clear tab configuration for.</param>
+    public static void ClearModSettingsTabs(BaseUnityPlugin plugin)
+        => ClearModSettingsTabs(plugin.Info.Metadata.GUID);
+
+    /// <summary>
+    /// Removes tab configuration for the given mod, restoring the default flat section layout.
+    /// </summary>
+    /// <param name="pluginGuid">The BepInEx GUID of the mod to clear tab configuration for.</param>
+    public static void ClearModSettingsTabs(string pluginGuid)
+        => ZeepSettingsTabsRegistry.ClearTabs(pluginGuid);
 
     /// <summary>
     /// Sets a custom display label for a config entry when using the default settings layout.

--- a/ZeepSDK/Settings/ZeepSettingsDrawer.cs
+++ b/ZeepSDK/Settings/ZeepSettingsDrawer.cs
@@ -21,6 +21,7 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
     {
         public PluginInfo Plugin { get; }
         public IReadOnlyList<IZeepSettingsDrawer> Drawers { get; }
+        public bool UsesTabbedLayout { get; }
 
         public SelectedPluginInfo(PluginInfo plugin)
         {
@@ -29,34 +30,18 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
             if (plugin == null)
             {
                 Drawers = [];
+                UsesTabbedLayout = false;
                 return;
             }
 
-            var entriesBySection = BuildEntriesBySection(plugin);
+            var entriesBySection = ModSettingsDrawerBuildContext.BuildEntriesBySection(plugin);
             var buildContext = new ModSettingsDrawerBuildContext(plugin, entriesBySection);
 
             Drawers = ZeepSettingsDrawerRegistry.TryGetProvider(plugin.Metadata.GUID, out var provider)
                 ? provider(buildContext).ToList()
                 : buildContext.CreateDefaultDrawers().ToList();
-        }
 
-        private static Dictionary<string, IReadOnlyList<ConfigEntryBase>> BuildEntriesBySection(PluginInfo plugin)
-        {
-            var sections = new Dictionary<string, SortedList<string, ConfigEntryBase>>();
-
-            foreach ((ConfigDefinition definition, ConfigEntryBase entry) in plugin.Instance.Config)
-            {
-                if (!sections.TryGetValue(definition.Section, out var entries))
-                {
-                    sections.Add(definition.Section, entries = []);
-                }
-
-                entries.Add(definition.Key, entry);
-            }
-
-            return sections.ToDictionary(
-                x => x.Key,
-                x => (IReadOnlyList<ConfigEntryBase>)[.. x.Value.Values]);
+            UsesTabbedLayout = Drawers.Any(d => d is ZeepSettingsTabbedSectionsDrawer);
         }
     }
 
@@ -70,6 +55,9 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
     private ConfigEntry<KeyCode> _currentKeyCodeEntry;
     private KeyCode _currentKeyCode;
     private float _keyCodeCountdown = 10f;
+
+    private const float TabbedFlatTailFraction = 0.3f;
+    private const float MinTabContentHeight = 300f;
 
     public ZeepSettingsDrawer()
     {
@@ -125,9 +113,12 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
 
                 using (gui.Vertical(gui.GetLayoutWidth(), maxHeight))
                 {
-                    using (gui.Scrollable())
+                    if (_selectedPluginInfo?.UsesTabbedLayout == true)
+                        DrawSelectedPluginWithPadding(gui, maxHeight);
+                    else
                     {
-                        DrawSelectedPluginWithPadding(gui);
+                        using (gui.Scrollable())
+                            DrawSelectedPluginWithPadding(gui);
                     }
                 }
             }
@@ -150,7 +141,7 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
         }
     }
 
-    private void DrawSelectedPluginWithPadding(ImGui gui)
+    private void DrawSelectedPluginWithPadding(ImGui gui, float maxContentHeight = 0f)
     {
         var padding = gui.Style.Window.ContentPadding;
         var contentWidth = Mathf.Max(0, gui.GetLayoutWidth() - padding.Left - padding.Right);
@@ -164,7 +155,7 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
                 if (padding.Top > 0)
                     gui.AddSpacing(padding.Top);
 
-                DrawSelectedPlugin(gui);
+                DrawSelectedPlugin(gui, maxContentHeight);
 
                 if (padding.Bottom > 0)
                     gui.AddSpacing(padding.Bottom);
@@ -174,18 +165,74 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
         }
     }
 
-    private void DrawSelectedPlugin(ImGui gui)
+    private void DrawSelectedPlugin(ImGui gui, float maxContentHeight = 0f)
     {
         if (_selectedPluginInfo?.Plugin == null)
-        {
             return;
-        }
 
         gui.Text(_selectedPluginInfo.Plugin.Metadata.Name, new ImTextSettings(48, 0.5f));
 
-        foreach (var drawer in _selectedPluginInfo.Drawers)
+        if (!_selectedPluginInfo.UsesTabbedLayout)
         {
-            drawer.Draw(gui, _drawContext);
+            foreach (var drawer in _selectedPluginInfo.Drawers)
+                drawer.Draw(gui, _drawContext);
+
+            return;
+        }
+
+        var drawers = _selectedPluginInfo.Drawers;
+        var tabDrawerIndex = -1;
+        for (var i = 0; i < drawers.Count; i++)
+        {
+            if (drawers[i] is ZeepSettingsTabbedSectionsDrawer)
+            {
+                tabDrawerIndex = i;
+                break;
+            }
+        }
+
+        if (tabDrawerIndex < 0)
+        {
+            foreach (var drawer in drawers)
+                drawer.Draw(gui, _drawContext);
+
+            return;
+        }
+
+        var remainingHeight = maxContentHeight > 0f
+            ? Mathf.Max(0f, maxContentHeight - gui.GetRowsHeightWithSpacing(1))
+            : 0f;
+
+        var flatDrawerCount = drawers.Count - tabDrawerIndex - 1;
+        if (remainingHeight > 0f)
+        {
+            _drawContext.AvailableContentHeight = flatDrawerCount > 0
+                ? Mathf.Max(MinTabContentHeight, remainingHeight * (1f - TabbedFlatTailFraction))
+                : remainingHeight;
+        }
+        else
+        {
+            _drawContext.AvailableContentHeight = 0f;
+        }
+
+        drawers[tabDrawerIndex].Draw(gui, _drawContext);
+        _drawContext.AvailableContentHeight = 0f;
+
+        if (flatDrawerCount <= 0)
+            return;
+
+        if (remainingHeight > 0f)
+        {
+            using (gui.Scrollable())
+            {
+                for (var i = tabDrawerIndex + 1; i < drawers.Count; i++)
+                    drawers[i].Draw(gui, _drawContext);
+            }
+        }
+        else
+        {
+            for (var i = tabDrawerIndex + 1; i < drawers.Count; i++)
+                drawers[i].Draw(gui, _drawContext);
         }
     }
 
@@ -232,7 +279,7 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
             }
 
             gui.Layout.Pop();
-            gui.Canvas.PopRectMask();
+            gui.Canvas.PopClipRect();
             gui.Canvas.PopClipRect();
             gui.EndPopup();
         }

--- a/ZeepSDK/Settings/ZeepSettingsDrawer.cs
+++ b/ZeepSDK/Settings/ZeepSettingsDrawer.cs
@@ -132,7 +132,8 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
     private void DrawSelectedPluginWithPadding(ImGui gui)
     {
         var padding = gui.Style.Window.ContentPadding;
-        var contentWidth = Mathf.Max(0, gui.GetLayoutWidth() - padding.Left - padding.Right);
+        var rightPadding = padding.Right + gui.Style.Layout.Spacing;
+        var contentWidth = Mathf.Max(0, gui.GetLayoutWidth() - padding.Left - rightPadding);
 
         using (gui.Horizontal(gui.GetLayoutWidth()))
         {
@@ -149,7 +150,7 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
                     gui.AddSpacing(padding.Bottom);
             }
 
-            gui.AddSpacing(padding.Right);
+            gui.AddSpacing(rightPadding);
         }
     }
 

--- a/ZeepSDK/Settings/ZeepSettingsDrawer.cs
+++ b/ZeepSDK/Settings/ZeepSettingsDrawer.cs
@@ -21,7 +21,6 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
     {
         public PluginInfo Plugin { get; }
         public IReadOnlyList<IZeepSettingsDrawer> Drawers { get; }
-        public bool UsesTabbedLayout { get; }
 
         public SelectedPluginInfo(PluginInfo plugin)
         {
@@ -30,7 +29,6 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
             if (plugin == null)
             {
                 Drawers = [];
-                UsesTabbedLayout = false;
                 return;
             }
 
@@ -40,8 +38,6 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
             Drawers = ZeepSettingsDrawerRegistry.TryGetProvider(plugin.Metadata.GUID, out var provider)
                 ? provider(buildContext).ToList()
                 : buildContext.CreateDefaultDrawers().ToList();
-
-            UsesTabbedLayout = Drawers.Any(d => d is ZeepSettingsTabbedSectionsDrawer);
         }
     }
 
@@ -55,9 +51,6 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
     private ConfigEntry<KeyCode> _currentKeyCodeEntry;
     private KeyCode _currentKeyCode;
     private float _keyCodeCountdown = 10f;
-
-    private const float TabbedFlatTailFraction = 0.3f;
-    private const float MinTabContentHeight = 300f;
 
     public ZeepSettingsDrawer()
     {
@@ -113,13 +106,8 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
 
                 using (gui.Vertical(gui.GetLayoutWidth(), maxHeight))
                 {
-                    if (_selectedPluginInfo?.UsesTabbedLayout == true)
-                        DrawSelectedPluginWithPadding(gui, maxHeight);
-                    else
-                    {
-                        using (gui.Scrollable())
-                            DrawSelectedPluginWithPadding(gui);
-                    }
+                    using (gui.Scrollable())
+                        DrawSelectedPluginWithPadding(gui);
                 }
             }
 
@@ -141,7 +129,7 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
         }
     }
 
-    private void DrawSelectedPluginWithPadding(ImGui gui, float maxContentHeight = 0f)
+    private void DrawSelectedPluginWithPadding(ImGui gui)
     {
         var padding = gui.Style.Window.ContentPadding;
         var contentWidth = Mathf.Max(0, gui.GetLayoutWidth() - padding.Left - padding.Right);
@@ -155,7 +143,7 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
                 if (padding.Top > 0)
                     gui.AddSpacing(padding.Top);
 
-                DrawSelectedPlugin(gui, maxContentHeight);
+                DrawSelectedPlugin(gui);
 
                 if (padding.Bottom > 0)
                     gui.AddSpacing(padding.Bottom);
@@ -165,75 +153,15 @@ internal class ZeepSettingsDrawer : IZeepGUIDrawer
         }
     }
 
-    private void DrawSelectedPlugin(ImGui gui, float maxContentHeight = 0f)
+    private void DrawSelectedPlugin(ImGui gui)
     {
         if (_selectedPluginInfo?.Plugin == null)
             return;
 
         gui.Text(_selectedPluginInfo.Plugin.Metadata.Name, new ImTextSettings(48, 0.5f));
 
-        if (!_selectedPluginInfo.UsesTabbedLayout)
-        {
-            foreach (var drawer in _selectedPluginInfo.Drawers)
-                drawer.Draw(gui, _drawContext);
-
-            return;
-        }
-
-        var drawers = _selectedPluginInfo.Drawers;
-        var tabDrawerIndex = -1;
-        for (var i = 0; i < drawers.Count; i++)
-        {
-            if (drawers[i] is ZeepSettingsTabbedSectionsDrawer)
-            {
-                tabDrawerIndex = i;
-                break;
-            }
-        }
-
-        if (tabDrawerIndex < 0)
-        {
-            foreach (var drawer in drawers)
-                drawer.Draw(gui, _drawContext);
-
-            return;
-        }
-
-        var remainingHeight = maxContentHeight > 0f
-            ? Mathf.Max(0f, maxContentHeight - gui.GetRowsHeightWithSpacing(1))
-            : 0f;
-
-        var flatDrawerCount = drawers.Count - tabDrawerIndex - 1;
-        if (remainingHeight > 0f)
-        {
-            _drawContext.AvailableContentHeight = flatDrawerCount > 0
-                ? Mathf.Max(MinTabContentHeight, remainingHeight * (1f - TabbedFlatTailFraction))
-                : remainingHeight;
-        }
-        else
-        {
-            _drawContext.AvailableContentHeight = 0f;
-        }
-
-        drawers[tabDrawerIndex].Draw(gui, _drawContext);
-        _drawContext.AvailableContentHeight = 0f;
-
-        if (flatDrawerCount <= 0)
-            return;
-
-        if (remainingHeight > 0f)
-        {
-            using (gui.Scrollable())
-            {
-                for (var i = tabDrawerIndex + 1; i < drawers.Count; i++)
-                    drawers[i].Draw(gui, _drawContext);
-            }
-        }
-        else
-        {
-            for (var i = tabDrawerIndex + 1; i < drawers.Count; i++)
-                drawers[i].Draw(gui, _drawContext);
-        }
+        foreach (var drawer in _selectedPluginInfo.Drawers)
+            drawer.Draw(gui, _drawContext);
     }
 
     private void DrawKeyPopup(ImGui gui)

--- a/ZeepSDK/Settings/ZeepSettingsTabsRegistry.cs
+++ b/ZeepSDK/Settings/ZeepSettingsTabsRegistry.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using BepInEx.Configuration;
+
+namespace ZeepSDK.Settings;
+
+/// <summary>
+/// Stores tab layout configuration per plugin GUID.
+/// </summary>
+internal static class ZeepSettingsTabsRegistry
+{
+    private static readonly Dictionary<string, IReadOnlyList<ModSettingsTabDefinition>> TabsByPlugin = new();
+
+    public static void Configure(
+        string pluginGuid,
+        Action<ModSettingsTabsBuilder> configure,
+        IReadOnlyDictionary<string, IReadOnlyList<ConfigEntryBase>> entriesBySection)
+    {
+        if (configure == null)
+            throw new ArgumentNullException(nameof(configure));
+
+        var builder = new ModSettingsTabsBuilder(entriesBySection, pluginGuid);
+        configure(builder);
+
+        var builtTabs = builder.Build();
+        if (builtTabs.Count == 0)
+        {
+            TabsByPlugin.Remove(pluginGuid);
+            return;
+        }
+
+        TabsByPlugin[pluginGuid] = builtTabs;
+    }
+
+    public static void ClearTabs(string pluginGuid) => TabsByPlugin.Remove(pluginGuid);
+
+    public static bool TryGetTabs(string pluginGuid, out IReadOnlyList<ModSettingsTabDefinition> tabs)
+        => TabsByPlugin.TryGetValue(pluginGuid, out tabs);
+
+    public static HashSet<string> GetAssignedSections(IReadOnlyList<ModSettingsTabDefinition> tabs)
+    {
+        var assigned = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var tab in tabs)
+        {
+            foreach (var item in tab.Items)
+            {
+                if (item is ModSettingsTabSectionItem sectionItem)
+                    assigned.Add(sectionItem.SectionName);
+            }
+        }
+
+        return assigned;
+    }
+}

--- a/docs/articles/custom-mod-settings-layout.md
+++ b/docs/articles/custom-mod-settings-layout.md
@@ -55,6 +55,9 @@ The build context gives your provider access to the plugin being drawn and its c
 | `Plugin` | The `PluginInfo` for the mod being rendered |
 | `EntriesBySection` | Config entries grouped by BepInEx section name |
 | `CreateDefaultDrawers()` | Builds the default drawer sequence, including any labels and per-entry callbacks you registered |
+| `CreateSectionDrawers(section)` | Builds drawers for a single BepInEx section |
+| `CreateFlatSectionDrawers(excludeTabbedSections)` | Builds flat section drawers, optionally omitting sections assigned to configured tabs |
+| `CreateTabbedSectionsDrawer(configure)` | Builds a tabbed drawer from a `ModSettingsTabsBuilder` callback |
 
 `CreateDefaultDrawers()` automatically includes:
 
@@ -95,6 +98,58 @@ yield return new ZeepSettingsSeparatorDrawer();
 ```
 
 The default layout inserts a separator after every visible entry.
+
+### `ZeepSettingsTabbedSectionsDrawer`
+
+Draws grouped settings content in a tabbed layout. Usually created via `ConfigureModSettingsTabs` or `CreateTabbedSectionsDrawer` rather than constructed directly.
+
+## Tabbed Layouts
+
+### Declarative Tabs
+
+Use `ConfigureModSettingsTabs` when you only need to group sections into tabs:
+
+```csharp
+SettingsApi.ConfigureModSettingsTabs(this, tabs =>
+{
+    tabs.Tab("Gameplay", "General", "Combat");
+    tabs.Tab("Audio", "Sound");
+});
+```
+
+Sections not assigned to any tab render flat below the tab bar. Each tab label is author-provided; merged sections still show their normal headers inside the tab.
+
+Add individual entries or custom drawers to a tab:
+
+```csharp
+tabs.Tab("Tools")
+    .Entry(_rebuildCache)
+    .Drawer(new HelpTextDrawer("Rebuilds on next load."))
+    .Drawer(new ZeepSettingsSeparatorDrawer());
+```
+
+Call `ClearModSettingsTabs` to restore the default flat layout.
+
+### Tabs in a Custom Provider
+
+Compose tabbed and flat content inside `RegisterModSettingsDrawers`:
+
+```csharp
+SettingsApi.RegisterModSettingsDrawers(this, context =>
+{
+    yield return context.CreateTabbedSectionsDrawer(tabs =>
+    {
+        tabs.Tab("Gameplay", "General", "Combat");
+        tabs.Tab("Audio", "Sound");
+        tabs.Tab("About").Drawer(new HelpTextDrawer("Adjust these settings in the main menu."));
+    });
+
+    foreach (var drawer in context.CreateFlatSectionDrawers(excludeTabbedSections: true))
+        yield return drawer;
+});
+```
+
+`CreateDefaultDrawers()` also honors tab configuration registered via `ConfigureModSettingsTabs`.
 
 ## Composing Layouts
 
@@ -280,6 +335,7 @@ Start with the default layout and add only what you need:
 - Custom labels → `SetConfigEntryLabel`
 - One special entry → `SetConfigEntryDrawer`
 - Shared custom type → `RegisterConfigEntryTypeDrawer`
+- Tabbed section grouping → `ConfigureModSettingsTabs`
 - Full layout control → `RegisterModSettingsDrawers`
 
 ### Use `CreateDefaultDrawers()` When Possible
@@ -299,6 +355,7 @@ Register your layout provider once during plugin initialization. The drawer list
 - Register a layout provider with `RegisterModSettingsDrawers`
 - Return `IEnumerable<IZeepSettingsDrawer>` from your provider callback
 - Use `ModSettingsDrawerBuildContext.CreateDefaultDrawers()` to compose with the default layout
+- Group sections into tabs with `ConfigureModSettingsTabs` or `CreateTabbedSectionsDrawer`
 - Use `ZeepSettingsHeaderDrawer`, `ZeepSettingsEntryDrawer`, and `ZeepSettingsSeparatorDrawer` to build layouts manually
 - Implement `IZeepSettingsDrawer` for fully custom content
 - Use `ZeepSettingsDrawContext.OpenKeyCodePopup` for KeyCode editing in custom UI

--- a/docs/articles/mod-settings.md
+++ b/docs/articles/mod-settings.md
@@ -170,6 +170,35 @@ When the default layout builds a row for a config entry, ZeepSDK resolves the dr
 
 Per-entry customization always takes priority over type-based customization.
 
+### Tabbed Sections
+
+Use `ConfigureModSettingsTabs` to group BepInEx sections into tabs without writing a custom layout provider. Tab labels are author-provided; section headers inside a tab are unchanged.
+
+```csharp
+SettingsApi.ConfigureModSettingsTabs(this, tabs =>
+{
+    tabs.Tab("Gameplay", "General", "Combat");
+    tabs.Tab("Audio", "Sound");
+});
+```
+
+Sections not assigned to any tab render as normal flat sections below the tab bar. Call `ClearModSettingsTabs` to restore the default flat layout.
+
+You can also add individual config entries or custom drawers to a tab:
+
+```csharp
+SettingsApi.ConfigureModSettingsTabs(this, tabs =>
+{
+    tabs.Tab("Gameplay", "General", "Combat");
+
+    tabs.Tab("Tools")
+        .Entry(_rebuildCache)
+        .Drawer(new HelpTextDrawer("Rebuilds on next load."));
+});
+```
+
+For full layout control with tabs, see **[Custom Mod Settings Layout](custom-mod-settings-layout.md)**.
+
 ## Basic Plugin Example
 
 ```csharp
@@ -219,3 +248,4 @@ If you need to reorder sections, insert custom content between entries, or repla
 - Customize individual entries with `SetConfigEntryDrawer` and `DrawDefault()`
 - Customize all entries of a type with `RegisterConfigEntryTypeDrawer`
 - Per-entry customization overrides type-based customization
+- Group sections into tabs with `ConfigureModSettingsTabs`


### PR DESCRIPTION
## Summary
Adds declarative tab support to the Zeep Settings window, so mods can group BepInEx config sections into tabs without writing a custom drawer provider.
- Adds `SettingsApi.ConfigureModSettingsTabs` and `ClearModSettingsTabs` for declarative tab configuration
- Introduces `ModSettingsTabsBuilder` to define tabs from sections, individual entries, or custom drawers
- Renders tabbed content via `ZeepSettingsTabbedSectionsDrawer`, integrated into the default settings layout
- Extends `ModSettingsDrawerBuildContext` with `CreateTabbedSectionsDrawer`, `CreateFlatSectionDrawers`, and related helpers for custom layouts
- Sections not assigned to a tab still render flat below the tab bar
- Fixes tab scrolling so content sizes naturally and the right settings panel scrolls as a whole (no nested scrollbar inside tabs)
- Adds a bit of extra right padding so entries don't sit flush against the scrollbar/window edge
- Documents tab configuration in `custom-mod-settings-layout.md` and `mod-settings.md`
### Example
```csharp
SettingsApi.ConfigureModSettingsTabs(this, tabs =>
{
    tabs.Tab("Gameplay", "General", "Combat");
    tabs.Tab("Audio", "Sound");
});