### PR TITLE
fix(settings): sort config entries by natural numeric order

### DIFF
--- a/ZeepSDK.Tests/NaturalStringComparerTests.cs
+++ b/ZeepSDK.Tests/NaturalStringComparerTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using ZeepSDK.Utilities;
+
+namespace ZeepSDK.Tests;
+
+public class NaturalStringComparerTests
+{
+    private static readonly NaturalStringComparer Comparer = NaturalStringComparer.Instance;
+
+    [Fact]
+    public void Compare_IntegerPrefixes_SortsNumerically()
+    {
+        var input = new[] { "10. Baz", "2. Bar", "1. Foo", "11. Qux" };
+        var expected = new[] { "1. Foo", "2. Bar", "10. Baz", "11. Qux" };
+
+        Assert.Equal(expected, Sort(input));
+    }
+
+    [Fact]
+    public void Compare_DecimalStylePrefixes_SortsNumerically()
+    {
+        var input = new[] { "2.10 Delta", "2.1 Alpha", "2.3 Gamma", "2.2 Beta" };
+        var expected = new[] { "2.1 Alpha", "2.2 Beta", "2.3 Gamma", "2.10 Delta" };
+
+        Assert.Equal(expected, Sort(input));
+    }
+
+    [Fact]
+    public void Compare_NonPrefixedStrings_SortsLexicographically()
+    {
+        var input = new[] { "Beta", "Alpha", "Charlie" };
+        var expected = new[] { "Alpha", "Beta", "Charlie" };
+
+        Assert.Equal(expected, Sort(input));
+    }
+
+    [Fact]
+    public void Compare_MixedPrefixedAndPlainStrings_SortsNaturally()
+    {
+        var input = new[] { "10. Item", "Alpha", "2. Item", "Beta", "1. Item" };
+        var expected = new[] { "1. Item", "2. Item", "10. Item", "Alpha", "Beta" };
+
+        Assert.Equal(expected, Sort(input));
+    }
+
+    [Fact]
+    public void Compare_NullAndEmpty_HandlesEdgeCases()
+    {
+        Assert.True(Comparer.Compare(null, "A") < 0);
+        Assert.True(Comparer.Compare("A", null) > 0);
+        Assert.Equal(0, Comparer.Compare(null, null));
+        Assert.True(Comparer.Compare(string.Empty, "A") < 0);
+        Assert.True(Comparer.Compare("A", string.Empty) > 0);
+        Assert.Equal(0, Comparer.Compare(string.Empty, string.Empty));
+        Assert.True(Comparer.Compare("A", "AB") < 0);
+    }
+
+    [Fact]
+    public void Compare_EqualStrings_ReturnsZero()
+    {
+        Assert.Equal(0, Comparer.Compare("2.1 Alpha", "2.1 Alpha"));
+    }
+
+    [Fact]
+    public void Compare_LeadingZeroPrefixes_TreatsDigitRunsNumerically()
+    {
+        var input = new[] { "01. Second", "1. First", "10. Third" };
+        var expected = new[] { "1. First", "01. Second", "10. Third" };
+
+        Assert.Equal(expected, Sort(input));
+    }
+
+    private static List<string> Sort(IEnumerable<string> values)
+        => values.OrderBy(x => x, Comparer).ToList();
+}

--- a/ZeepSDK.Tests/ZeepSDK.Tests.csproj
+++ b/ZeepSDK.Tests/ZeepSDK.Tests.csproj
@@ -27,6 +27,7 @@
         <Compile Include="..\ZeepSDK\Level\LevelHashV2Calculator.cs" Link="Source\LevelHashV2Calculator.cs" />
         <Compile Include="..\ZeepSDK\Numerics\Vector2.cs" Link="Source\Vector2.cs" />
         <Compile Include="..\ZeepSDK\Numerics\Vector3.cs" Link="Source\Vector3.cs" />
+        <Compile Include="..\ZeepSDK\Utilities\NaturalStringComparer.cs" Link="Source\NaturalStringComparer.cs" />
         <Compile Include="..\ZeepSDK\Utilities\SequenceComparer.cs" Link="Source\SequenceComparer.cs" />
         <Compile Include="..\ZeepSDK\Utilities\Vector3Comparer.cs" Link="Source\Vector3Comparer.cs" />
         <Compile Include="..\ZeepSDK\Utilities\XxHash128Reflection.cs" Link="Source\XxHash128Reflection.cs" />

--- a/ZeepSDK/Settings/ModSettingsDrawerBuildContext.cs
+++ b/ZeepSDK/Settings/ModSettingsDrawerBuildContext.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using BepInEx;
 using BepInEx.Configuration;
 using ZeepSDK.Settings.Drawers;
+using ZeepSDK.Utilities;
 
 namespace ZeepSDK.Settings;
 
@@ -113,18 +113,44 @@ public sealed class ModSettingsDrawerBuildContext
 
     internal static Dictionary<string, IReadOnlyList<ConfigEntryBase>> BuildEntriesBySection(PluginInfo plugin)
     {
-        var sections = new Dictionary<string, SortedList<string, ConfigEntryBase>>();
+        var customLabels = ZeepSettingsEntryLabelRegistry.GetLabels(plugin.Metadata.GUID);
+        var sections = new Dictionary<string, List<ConfigEntryBase>>();
 
         foreach ((ConfigDefinition definition, ConfigEntryBase entry) in plugin.Instance.Config)
         {
             if (!sections.TryGetValue(definition.Section, out var entries))
                 sections.Add(definition.Section, entries = []);
 
-            entries.Add(definition.Key, entry);
+            entries.Add(entry);
         }
 
-        return sections.ToDictionary(
-            x => x.Key,
-            x => (IReadOnlyList<ConfigEntryBase>)[.. x.Value.Values]);
+        foreach (var entries in sections.Values)
+        {
+            entries.Sort((a, b) =>
+            {
+                int cmp = NaturalStringComparer.Instance.Compare(
+                    GetEntrySortKey(a, customLabels),
+                    GetEntrySortKey(b, customLabels));
+                return cmp != 0
+                    ? cmp
+                    : string.Compare(a.Definition.Key, b.Definition.Key, StringComparison.Ordinal);
+            });
+        }
+
+        var result = new Dictionary<string, IReadOnlyList<ConfigEntryBase>>(sections.Count);
+        foreach ((string section, List<ConfigEntryBase> entries) in sections)
+            result[section] = entries;
+
+        return result;
+    }
+
+    private static string GetEntrySortKey(
+        ConfigEntryBase entry,
+        IReadOnlyDictionary<ConfigDefinition, string> customLabels)
+    {
+        if (customLabels != null && customLabels.TryGetValue(entry.Definition, out var label) && label != null)
+            return label;
+
+        return entry.Definition.Key;
     }
 }

--- a/ZeepSDK/Utilities/NaturalStringComparer.cs
+++ b/ZeepSDK/Utilities/NaturalStringComparer.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+
+namespace ZeepSDK.Utilities;
+
+internal sealed class NaturalStringComparer : IComparer<string>
+{
+    public static NaturalStringComparer Instance { get; } = new();
+
+    private NaturalStringComparer()
+    {
+    }
+
+    public int Compare(string x, string y)
+    {
+        if (ReferenceEquals(x, y))
+            return 0;
+
+        if (x == null)
+            return -1;
+
+        if (y == null)
+            return 1;
+
+        int ix = 0;
+        int iy = 0;
+
+        while (ix < x.Length && iy < y.Length)
+        {
+            char cx = x[ix];
+            char cy = y[iy];
+
+            if (char.IsDigit(cx) && char.IsDigit(cy))
+            {
+                long nx = ReadNumber(x, ref ix);
+                long ny = ReadNumber(y, ref iy);
+                int numberComparison = nx.CompareTo(ny);
+                if (numberComparison != 0)
+                    return numberComparison;
+
+                continue;
+            }
+
+            if (cx != cy)
+                return cx.CompareTo(cy);
+
+            ix++;
+            iy++;
+        }
+
+        return x.Length.CompareTo(y.Length);
+    }
+
+    private static long ReadNumber(string value, ref int index)
+    {
+        long number = 0;
+
+        while (index < value.Length && char.IsDigit(value[index]))
+        {
+            number = (number * 10) + (value[index] - '0');
+            index++;
+        }
+
+        return number;
+    }
+}


### PR DESCRIPTION
Replace lexicographic SortedList ordering with natural comparison on display labels so numbered prefixes like 1., 2., and 10. appear in numeric order.