### PR TITLE
fix(settings): hash tab index scopes with parent control ids

### DIFF
--- a/ZeepSDK/Settings/Drawers/ZeepSettingsTabbedSectionsDrawer.cs
+++ b/ZeepSDK/Settings/Drawers/ZeepSettingsTabbedSectionsDrawer.cs
@@ -47,7 +47,7 @@ public sealed class ZeepSettingsTabbedSectionsDrawer : IZeepSettingsDrawer
                     for (var i = 0; i < _tabs.Count; i++)
                     {
                         var tab = _tabs[i];
-                        gui.PushId((uint)i);
+                        gui.PushId(gui.GetControlId((uint)i));
                         {
                             var controlId = gui.GetNextControlId();
                             var rect = ImTabsPane.AddButtonRect(gui, tab.Label, default);
@@ -70,7 +70,7 @@ public sealed class ZeepSettingsTabbedSectionsDrawer : IZeepSettingsDrawer
 
             gui.PushId("content");
             {
-                gui.PushId((uint)_selectedTabIndex);
+                gui.PushId(gui.GetControlId((uint)_selectedTabIndex));
                 {
                     foreach (var drawer in _tabs[_selectedTabIndex].Drawers)
                         drawer.Draw(gui, context);


### PR DESCRIPTION
PushId(uint) ignores the parent scope, so tab buttons and tab content still collided after separating tabs/content namespaces. Use GetControlId so indices are hashed under their respective scopes and tooltips no longer appear when hovering tab buttons.